### PR TITLE
Create database(s) and tables entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Gain visibility on your Rails application data model and identify bottlenecks. I
 
 ## Features
 
+- Application Databases and Tables
 - ActiveRecord Models
     - Metadata, e.g size, indexes
     - Columns (disabled by default)
@@ -65,6 +66,10 @@ RailsGraph.configure do |config|
 
   # Configure Class Hierarchy parsing
   config.inheritance = true
+
+  # Configure Database entities
+  # default true
+  config.database = false
 
   # Configure inclusion of Packwerk packages
   # default false

--- a/lib/rails_graph/commands/build_graph.rb
+++ b/lib/rails_graph/commands/build_graph.rb
@@ -6,8 +6,10 @@ require_relative "../graph/relationship"
 
 require_relative "../graph/nodes/abstract_model"
 require_relative "../graph/nodes/column"
+require_relative "../graph/nodes/database"
 require_relative "../graph/nodes/model"
 require_relative "../graph/nodes/pack"
+require_relative "../graph/nodes/table"
 require_relative "../graph/nodes/virtual_model"
 
 require_relative "../graph/relationships/association"
@@ -21,6 +23,7 @@ require_relative "../helpers/models"
 
 require_relative "./builders/models"
 require_relative "./builders/packs"
+require_relative "./builders/databases"
 
 module RailsGraph
   module Commands
@@ -32,6 +35,7 @@ module RailsGraph
       def call
         setup_generic_nodes
 
+        RailsGraph::Commands::Builders::Databases.enrich(graph: graph) if configuration.databases?
         RailsGraph::Commands::Builders::Models.enrich(graph: graph, classes: classes, configuration: configuration)
         build_inheritance_relationships if configuration.inheritance?
         RailsGraph::Commands::Builders::Packs.enrich(graph: graph) if configuration.include_packwerk?

--- a/lib/rails_graph/commands/builders/databases.rb
+++ b/lib/rails_graph/commands/builders/databases.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+module RailsGraph
+  module Commands
+    module Builders
+      class Databases
+        def self.enrich(graph:)
+          new(graph: graph).enrich
+
+          graph
+        end
+
+        def enrich
+          build_databases_nodes
+          build_tables_nodes
+        end
+
+        private
+
+        attr_reader :graph
+
+        def initialize(graph:)
+          @graph = graph
+        end
+
+        def build_databases_nodes
+          databases.each do |config|
+            node = RailsGraph::Graph::Nodes::Database.new(config)
+            graph.add_node(node)
+          end
+        end
+
+        def build_tables_nodes
+          ActiveRecord::Base.connection_handler.connection_pools.each do |connection_pool|
+            tables = connection_pool.connection.tables
+            database_name = connection_pool.db_config.name
+            database_node = graph.node("database_#{database_name}")
+
+            tables.each do |table|
+              table_node = RailsGraph::Graph::Nodes::Table.new(table, database_name)
+              graph.add_node(table_node)
+
+              relationship = RailsGraph::Graph::Relationship.new(
+                source: table_node,
+                target: database_node,
+                label: "PersistedIn",
+                name: "persisted_in",
+                properties: {}
+              )
+              graph.add_relationship(relationship)
+            end
+          end
+        end
+
+        def databases
+          @databases ||= ActiveRecord::Base.configurations.configs_for(env_name: Rails.env)
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_graph/configuration.rb
+++ b/lib/rails_graph/configuration.rb
@@ -2,13 +2,13 @@
 
 module RailsGraph
   class Configuration
-    attr_accessor :include_packwerk
     attr_reader :include_classes
-    attr_writer :columns, :inheritance
+    attr_writer :columns, :inheritance, :include_packwerk, :databases
 
     def initialize
       @include_classes = []
       @include_packwerk = false
+      @databases = true
       @columns = false
       @inheritance = true
     end
@@ -27,6 +27,10 @@ module RailsGraph
 
     def include_packwerk?
       @include_packwerk
+    end
+
+    def databases?
+      @databases
     end
   end
 end

--- a/lib/rails_graph/graph/nodes/database.rb
+++ b/lib/rails_graph/graph/nodes/database.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative "../node"
+
+module RailsGraph
+  module Graph
+    module Nodes
+      class Database < Node
+        attr_reader :configs
+
+        def initialize(configs)
+          @configs = configs
+
+          super(labels: "Database", name: configs.name, properties: build_properties)
+        end
+
+        def identifier
+          "database_#{name}"
+        end
+        
+        private
+
+        def build_properties
+          {
+            pool_size: configs.pool,
+            adapter: configs.adapter,
+            schema_cache_path: configs.schema_cache_path,
+            replica: configs.replica? || false,
+            database_name: configs.database,
+            reaping_frequency: configs.reaping_frequency,
+            min_threads: configs.min_threads,
+            max_threads: configs.max_threads
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/rails_graph/graph/nodes/pack.rb
+++ b/lib/rails_graph/graph/nodes/pack.rb
@@ -6,26 +6,22 @@ module RailsGraph
   module Graph
     module Nodes
       class Pack < Node
-        attr_reader :pack_name, :pack_owner
+        attr_reader :pack_owner
 
         def initialize(name, owner)
-          @pack_name = name
           @pack_owner = owner
 
-          super(labels: "Pack", name: pack_name, properties: build_properties)
+          super(labels: "Pack", name: name, properties: build_properties)
         end
 
         def identifier
-          pack_name
+          name
         end
 
         private
 
         def build_properties
-          {
-            name: pack_name,
-            owner: pack_owner
-          }
+          { owner: pack_owner }
         end
       end
     end

--- a/lib/rails_graph/graph/nodes/table.rb
+++ b/lib/rails_graph/graph/nodes/table.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require_relative "../node"
+
+module RailsGraph
+  module Graph
+    module Nodes
+      class Table < Node
+        attr_reader :name, :database_name
+
+        def initialize(name, database_name)
+          @database_name = database_name
+
+          super(labels: "Table", name: name, properties: build_properties)
+        end
+
+        def identifier
+          "table_#{database_name}.#{name}"
+        end
+
+        private
+
+        def build_properties
+          {
+            database_name: database_name
+          }
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds two node types, `Database` and `Table` and creates two new relationships. It also supports parsing multiple databases.

- `Model` entities will reference the corresponding `Table` entity using the `RepresentsTable` relationship, if any.
- `Table` entities will reference the `Database` entity using `PersistedIn` relationship.

Screenshot from the [example app](https://github.com/ahmad-elassuty/rails_graph_example)
<img width="581" alt="Screenshot 2023-05-20 at 8 57 32 AM" src="https://github.com/ahmad-elassuty/rails_graph/assets/4674035/1f093d73-3035-4280-811f-d2ca234d3b12">
